### PR TITLE
auth() received invalid user or password

### DIFF
--- a/lib/utils/snapshot.js
+++ b/lib/utils/snapshot.js
@@ -49,18 +49,21 @@ class Snapshot {
    */
   getSnapshot (callback) {
     const promise = new Promise((resolve, reject) => {
-      Request({
+      const params = {
         method: 'GET',
         uri: this.snapshotUri,
         gzip: true,
-        encoding: 'binary',
-        auth: {
+        encoding: 'binary'
+      };
+      if(typeof this.username === "string" && typeof this.password === "string") {
+        // Authentication is required only when 'username' and 'password' are provided
+        params.auth = {
           user: this.username,
           pass: this.password,
           sendImmediately: false
-        }
-      },
-      (error, response, body) => {
+        };
+      }
+      Request(params, (error, response, body) => {
         if (error) {
           reject(error)
           return

--- a/lib/utils/snapshot.js
+++ b/lib/utils/snapshot.js
@@ -54,14 +54,14 @@ class Snapshot {
         uri: this.snapshotUri,
         gzip: true,
         encoding: 'binary'
-      };
-      if(typeof this.username === "string" && typeof this.password === "string") {
+      }
+      if (typeof this.username === 'string' && typeof this.password === 'string') {
         // Authentication is required only when 'username' and 'password' are provided
         params.auth = {
           user: this.username,
           pass: this.password,
           sendImmediately: false
-        };
+        }
       }
       Request(params, (error, response, body) => {
         if (error) {


### PR DESCRIPTION
Avoid error: auth() received invalid user or password
when the camera does not have username and password for example using Android IP Webcam application: https://play.google.com/store/apps/details?id=com.pas.webcam&hl=it