### PR TITLE
Patch 3

### DIFF
--- a/lib/camera.js
+++ b/lib/camera.js
@@ -462,7 +462,7 @@ class Camera {
     return new Promise((resolve, reject) => {
       this.core.getScopes()
         .then(results => {
-          const scopes = results.data.GetScopesResponse.hasOwnProperty('Scopes') ? results.data.GetScopesResponse.Scopes : []
+          const scopes = Object.prototype.hasOwnProperty(results.data.GetScopesResponse, 'Scopes') ? results.data.GetScopesResponse.Scopes : []
           this.deviceInformation.Ptz = false
           scopes.forEach((scope) => {
             const s = scope.ScopeItem

--- a/lib/camera.js
+++ b/lib/camera.js
@@ -462,7 +462,7 @@ class Camera {
     return new Promise((resolve, reject) => {
       this.core.getScopes()
         .then(results => {
-          const scopes = results.data.GetScopesResponse.Scopes
+          const scopes = results.data.GetScopesResponse.hasOwnProperty('Scopes') ? results.data.GetScopesResponse.Scopes : []
           this.deviceInformation.Ptz = false
           scopes.forEach((scope) => {
             const s = scope.ScopeItem

--- a/lib/camera.js
+++ b/lib/camera.js
@@ -462,7 +462,10 @@ class Camera {
     return new Promise((resolve, reject) => {
       this.core.getScopes()
         .then(results => {
-          const scopes = Object.prototype.hasOwnProperty(results.data.GetScopesResponse, 'Scopes') ? results.data.GetScopesResponse.Scopes : []
+          const scopes = results.data.GetScopesResponse.Scopes
+          if (typeof scopes === 'undefined' || !Array.isArray(scopes)) {
+            scopes = []
+          }
           this.deviceInformation.Ptz = false
           scopes.forEach((scope) => {
             const s = scope.ScopeItem

--- a/lib/camera.js
+++ b/lib/camera.js
@@ -462,10 +462,7 @@ class Camera {
     return new Promise((resolve, reject) => {
       this.core.getScopes()
         .then(results => {
-          const scopes = results.data.GetScopesResponse.Scopes
-          if (typeof scopes === 'undefined' || !Array.isArray(scopes)) {
-            scopes = []
-          }
+          const scopes = typeof results.data.GetScopesResponse.Scopes === 'undefined' || !Array.isArray(results.data.GetScopesResponse.Scopes) ? [] : results.data.GetScopesResponse.Scopes
           this.deviceInformation.Ptz = false
           scopes.forEach((scope) => {
             const s = scope.ScopeItem

--- a/lib/camera.js
+++ b/lib/camera.js
@@ -547,6 +547,11 @@ class Camera {
   parseProfiles (profiles) {
     const profileList = []
 
+    // When a single profile is given 'profiles' is the single profile
+    if (!Array.isArray(profiles)) {
+      profiles = [profiles]
+    }
+
     profiles.forEach((profile) => {
       profileList.push(profile)
       if (!this.defaultProfile) {


### PR DESCRIPTION
Fix issue reported into the issue number #12 

And the issue:
Avoiding TypeError: Cannot read property 'forEach' of undefined
Using some cameras the getScopes core functionality can return an object like data: { GetScopesResponse: '' }.
An example is using the application Android IP Webcam: https://play.google.com/store/apps/details?id=com.pas.webcam&hl=it