### PR TITLE
fix cache key

### DIFF
--- a/dist/onvif-nvt.js
+++ b/dist/onvif-nvt.js
@@ -28,7 +28,8 @@ class OnvifManager {
         return;
       }
 
-      const c = this.cameras[address];
+      const cacheKey = `${address}:${port}`;
+      const c = this.cameras[cacheKey];
 
       if (c) {
         resolve(c);
@@ -41,7 +42,7 @@ class OnvifManager {
 
       const camera = new Camera();
       return camera.connect(address, port, username, password, servicePath).then(results => {
-        this.cameras[address] = camera;
+        this.cameras[cacheKey] = camera;
         resolve(camera);
       }).catch(error => {
         console.error(error);

--- a/lib/onvif-nvt.js
+++ b/lib/onvif-nvt.js
@@ -44,8 +44,8 @@ class OnvifManager {
         reject(new Error('The "address" argument for connect is invalid: ' + errMsg))
         return
       }
-
-      const c = this.cameras[address]
+      const cacheKey = `${address}:${port}`
+      const c = this.cameras[cacheKey]
       if (c) {
         resolve(c)
         return
@@ -60,7 +60,7 @@ class OnvifManager {
       return camera.connect(address, port, username, password, servicePath)
         .then(results => {
           // cache camera after successfully connecting
-          this.cameras[address] = camera
+          this.cameras[cacheKey] = camera
           resolve(camera)
         })
         .catch(error => {


### PR DESCRIPTION
If we have multiple ip cameras with the same address but with different port the cache implementation does not work as expected, to solve that we can change the storage key to use the address and the port.